### PR TITLE
Feat: Visual adjustments

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -41,6 +41,7 @@ nav a.router-link-exact-active:hover {
 main {
   margin: 0 25px;
   min-height: 500px;
-  min-width: 80vw;
+  width: 80vw;
+  max-width: 800px;
 }
 </style>

--- a/src/components/query/QueryMenu.vue
+++ b/src/components/query/QueryMenu.vue
@@ -15,9 +15,7 @@ const userStore = useUserStore();
 const { retrieveQuerySettings, saveQuerySettings } = userStore;
 const { setVariable, setup } = queryStore;
 onBeforeMount(async () => {
-  console.log(route.params);
   const querySettings = await retrieveQuerySettings(queryName);
-  console.log(querySettings);
   setup(querySettings);
 });
 const { queryBaseState, queryVariablesState, fullQuery } = storeToRefs(queryStore);

--- a/src/components/query/QueryMenu.vue
+++ b/src/components/query/QueryMenu.vue
@@ -46,8 +46,10 @@ const onSaveQuery = async () => {
 
     <div>
       <h2>Create new Variable</h2>
-      <input v-model="newVariableName" type="text" />
-      <button @click.prevent="onCreate">Create</button>
+      <div class="controls">
+        <input v-model="newVariableName" type="text" />
+        <button @click.prevent="onCreate">Create</button>
+      </div>
     </div>
     <div>
       <VariableInput
@@ -59,9 +61,7 @@ const onSaveQuery = async () => {
     <div>
       <h2>Full Query</h2>
       <CopyToClipboard name="full query" :to-copy="fullQuery" />
-      <p class="query">
-        {{ fullQuery }}
-      </p>
+      <textarea class="query" :value="fullQuery" disabled></textarea>
     </div>
   </div>
 </template>
@@ -77,15 +77,32 @@ textarea {
   margin: 5px 0;
   display: block;
   min-height: 200px;
-  min-width: 400px;
+  min-width: 70%;
+  /* width: 500px; */
 }
-p.query {
+.controls  {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 300px;
+}
+.controls > button {
+  width: fit-content;
+  flex-basis: 10%;
+  margin-top: 5px;
+}
+.query {
   background-color: gray;
   border: solid 1px black;
   border-radius: 20px;
+  border-bottom-right-radius: 0;
   padding: 15px;
   width: fit-content;
   margin: 15px 0;
   color: white;
+}
+.query:disabled {
+  opacity: 1;
 }
 </style>

--- a/src/components/query/VariableInput.vue
+++ b/src/components/query/VariableInput.vue
@@ -3,9 +3,9 @@ import { useQueryStore } from '@/stores/query';
 import CopyToClipboard from '../CopyToClipboard.vue';
 const props = defineProps<{ name: string }>();
 const { name } = props;
-let value = '';
 const queryStore = useQueryStore();
-const { setVariable, deleteVariable, getVariableAnchor } = queryStore;
+const { setVariable, getVariable, deleteVariable, getVariableAnchor } = queryStore;
+let value = getVariable(name);
 const onSave = () => {
   setVariable(name, value);
 };

--- a/src/stores/query.ts
+++ b/src/stores/query.ts
@@ -25,6 +25,15 @@ export const useQueryStore = defineStore('query', () => {
     queryBaseState.value = newBase;
   }
 
+  function getVariable(name: string): string {
+    const queryVariables = queryVariablesState.value;
+    const variable = queryVariables[name];
+    if (!variable) {
+      throw new Error(`Variable with this name(${name}) is not found.`);
+    }
+    return variable.value;
+  }
+
   function setVariable(name: string, value: string = '') {
     const queryVariables = queryVariablesState.value;
     queryVariables[name] = { name, value };
@@ -50,6 +59,7 @@ export const useQueryStore = defineStore('query', () => {
     fullQuery,
     setQueryBase,
     setVariable,
+    getVariable,
     deleteVariable,
     getVariableAnchor,
     setup,

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -22,8 +22,6 @@ export const useUserStore = defineStore('user', () => {
     const querySnapshot = await getDocs(subCollection);
     const allData: UserQueries = {};
     querySnapshot.forEach((doc) => {
-      // doc.data() is never undefined for query doc snapshots
-      console.log(doc.id, ' => ', doc.data());
       if (doc.exists()) {
         const data = doc.data() as QuerySettings;
         allData[data.queryName] = data;
@@ -63,10 +61,8 @@ async function getDocument(subCollectionPath: string[]): Promise<QuerySettings> 
 
   if (docSnap.exists()) {
     const data = docSnap.data() as QuerySettings;
-    console.log('Document data:', data);
     return data;
   } else {
-    console.log('No such document!');
     throw new Error('Document not found.');
   }
 }


### PR DESCRIPTION
What's done:
- Small tweaks to visuals
- Fix to an error when different query variables are saved with value of the only non-empty one
- Fix to an error of not loading in the value for a saved query variable(field was empty, but value was loaded behind the scenes)
- Visual adjustemnts for a Full query display:
  - For queries longer than 100 characters it went off screen, due to improper size settings on <main> element.
  - New lines weren't shown properly in paragraph element, showing it as one straight line
- Removed some dev logs left previously, that are now unneeded.